### PR TITLE
Added automated tests for all major platforms and fixed Issue #40 where timidity wasn't running on macOS arm64 chips 

### DIFF
--- a/.github/workflows/code-tests.yml
+++ b/.github/workflows/code-tests.yml
@@ -24,7 +24,7 @@ jobs:
         # github action doesn't goes well with windows due to docker support
         # github action doesn't goes well with macos due to `no docker command`
         #os: [ubuntu-20.04, windows-latest, macos-latest]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
     runs-on: ${{ matrix.os }}
     # map step outputs to job outputs so they can be share among jobs
     outputs:

--- a/.github/workflows/code-tests.yml
+++ b/.github/workflows/code-tests.yml
@@ -21,9 +21,6 @@ jobs:
     strategy:
       matrix:
         python_versions: ['3.9', '3.10', '3.11']
-        # github action doesn't goes well with windows due to docker support
-        # github action doesn't goes well with macos due to `no docker command`
-        #os: [ubuntu-20.04, windows-latest, macos-latest]
         os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
     runs-on: ${{ matrix.os }}
     # map step outputs to job outputs so they can be share among jobs
@@ -34,21 +31,8 @@ jobs:
       repo_owner: ${{ steps.variables_step.outputs.repo_owner }}
       build_number: ${{ steps.variables_step.outputs.build_number }}
 
-    # uncomment the following to pickup services
-    # services:
-    #   redis:
-    #     image: redis
-    #     options: >-
-    #       --health-cmd "redis-cli ping"
-    #       --health-interval 10s
-    #       --health-timeout 5s
-    #       --health-retries 5
-    #     ports:
-    #       - 6379:6379
-
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
@@ -105,72 +89,3 @@ jobs:
           poetry version $(poetry version --short)-dev.$GITHUB_RUN_NUMBER
           poetry lock
           poetry build
-
-  #notification:
-  #  needs: [test,publish_dev_build]
-  #  if: always()
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #    - uses: martialonline/workflow-status@v2
-  #      id: check
-#
-  #    - name: build success notification via email
-  #      if: ${{ steps.check.outputs.status == 'success' }}
-  #      uses: dawidd6/action-send-mail@v3
-  #      with:
-  #        server_address: ${{ secrets.BUILD_NOTIFY_MAIL_SERVER }}
-  #        server_port: ${{ secrets.BUILD_NOTIFY_MAIL_PORT }}
-  #        username: ${{ secrets.BUILD_NOTIFY_MAIL_FROM }}
-  #        password: ${{ secrets.BUILD_NOTIFY_MAIL_PASSWORD }}
-  #        from: build-bot
-  #        to: ${{ secrets.BUILD_NOTIFY_MAIL_RCPT }}
-  #        subject: ${{ needs.test.outputs.package_name }}.${{ needs.test.outputs.package_version}}.dev.${{ github.run_number }} build successfully
-  #        convert_markdown: true
-  #        html_body: |
-  #          ## Build Success
-  #          ${{ needs.test.outputs.package_name }}.${{ needs.test.outputs.package_version }}.dev.${{ github.run_number }} is built and published to test pypi
-#
-  #          ## Change Details
-  #          ${{ github.event.head_commit.message }}
-#
-  #          For more information, please check change history at https://${{ needs.test.outputs.repo_owner }}.github.io/${{ needs.test.outputs.repo_name }}/${{ needs.test.outputs.package_version }}.dev/history
-#
-  #          ## Package Download
-  #          The pacakge is available at: https://test.pypi.org/project/${{ needs.test.outputs.package_name }}/
-#
-  #    - name: build failure notification via email
-  #      if: ${{ steps.check.outputs.status == 'failure' }}
-  #      uses: dawidd6/action-send-mail@v3
-  #      with:
-  #        server_address: ${{ secrets.BUILD_NOTIFY_MAIL_SERVER }}
-  #        server_port: ${{ secrets.BUILD_NOTIFY_MAIL_PORT }}
-  #        username: ${{ secrets.BUILD_NOTIFY_MAIL_FROM }}
-  #        password: ${{ secrets.BUILD_NOTIFY_MAIL_PASSWORD }}
-  #        from: build-bot
-  #        to: ${{ secrets.BUILD_NOTIFY_MAIL_RCPT }}
-  #        subject: ${{ needs.test.outputs.package_name }}.${{ needs.test.outputs.package_version}}.dev.${{ github.run_number }} build failure
-  #        convert_markdown: true
-  #        html_body: |
-  #          ## Change Details
-  #          ${{ github.event.head_commit.message }}
-#
-  #          ## View Log
-  #          https://github.com/${{ needs.test.outputs.repo_owner }}/${{ needs.test.outputs.repo_name }}/actions
-
-
-      # - name: Dingtalk Robot Notify
-      #   if: always()
-      #   uses: leafney/dingtalk-action@v1.0.0
-      #   env:
-      #     DINGTALK_ACCESS_TOKEN: ${{ secrets.DINGTALK_ACCESS_TOKEN }}
-      #     DINGTALK_SECRET: ${{ secrets.DINGTALK_SECRET }}
-      #   with:
-      #     msgtype: markdown
-      #     title: CI Notification | Success
-      #     text: |
-      #       ### Build Success
-      #       ${{ needs.test.outputs.package_version }}.dev.${{ github.run_number }}published to TEST pypi
-      #       ### Change History
-      #       Please check change history at https://${{ needs.test.outputs.repo_owner }}.github.io/${{ needs.test.outputs.repo_name }}/${{ needs.test.outputs.package_version }}.dev/history
-      #       ### Package Download
-      #       The pacakge is availabled at: https://test.pypi.org/project/${{ needs.test.outputs.repo_name }}/

--- a/.github/workflows/code-tests.yml
+++ b/.github/workflows/code-tests.yml
@@ -24,7 +24,7 @@ jobs:
         # github action doesn't goes well with windows due to docker support
         # github action doesn't goes well with macos due to `no docker command`
         #os: [ubuntu-20.04, windows-latest, macos-latest]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     # map step outputs to job outputs so they can be share among jobs
     outputs:

--- a/.github/workflows/code-tests.yml
+++ b/.github/workflows/code-tests.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install Timidity on macOS
         if: runner.os == 'macOS'
         run: |
-          sudo brew install timidity
+          brew install timidity
 
       # declare package_version, repo_owner, repo_name, package_name so you may use it in web hooks.
       - name: Declare variables for convenient use on Linux

--- a/.github/workflows/code-tests.yml
+++ b/.github/workflows/code-tests.yml
@@ -59,13 +59,20 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox tox-gh-actions poetry
 
-      - name: Install Timidity
+      - name: Install Timidity on Linux
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update && sudo apt-get install -y timidity
 
+      - name: Install Timidity on macOS
+        if: runner.os == 'macOS'
+        run: |
+          sudo brew install timidity
+
       # declare package_version, repo_owner, repo_name, package_name so you may use it in web hooks.
-      - name: Declare variables for convenient use
+      - name: Declare variables for convenient use on Linux
         id: variables_step
+        if: runner.os == 'Linux'
         run: |
           echo "::set-output name=repo_owner::${GITHUB_REPOSITORY%/*}"
           echo "::set-output name=repo_name::${GITHUB_REPOSITORY#*/}"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ To install qMuVi, you can use `pip`:
 pip install qmuvi
 ```
 
+## macOS (Apple Silicon/ARM64)
+For macOS systems with 64-bit ARM processors (M1, M2, M3 chips), TiMidity++ must be installed manually:
+```bash
+brew install timidity
+```
+
 ## Linux
 For Linux, qMuVi requires timidity to be installed separately. Instructions for common distributions:
 ```bash

--- a/qmuvi/musical_processing.py
+++ b/qmuvi/musical_processing.py
@@ -455,11 +455,12 @@ def convert_midi_to_wav_timidity(output_manager: data_manager.DataManager, timeo
                 if command is None:
                     # Fallback to system timidity
                     system_binary = shutil.which("timidity")
+                    if log_to_file is True:
+                        log.info(f"Using system (OS: Darwin) timitidy: {system_binary}")  # type: ignore
+
                     binary_path = system_binary
                     if system_binary:
-                        if log_to_file is True:
-                            log.info(f"timidity system_binary (OS: Darwin): {system_binary}")  # type: ignore
-                        command = [system_binary] + options + ["-o", f'"{filename}.wav"', f'"{filename}.mid"']
+                        command = [system_binary] + options + ["-o", f'{filename}.wav', f'{filename}.mid']
                     else:
                         raise RuntimeError("System timidity not found and bundled version is not working. Please install timidity via 'brew install timidity'")
             else:

--- a/qmuvi/musical_processing.py
+++ b/qmuvi/musical_processing.py
@@ -393,7 +393,12 @@ def convert_midi_to_wav_timidity(output_manager: data_manager.DataManager, timeo
 
     package_path = os.path.dirname(os.path.realpath(__file__))
     config_filepath = os.path.join(package_path, "package_data", "resources", "timidity", "timidity.cfg")
-    options.append(f'--config-file={config_filepath}')
+
+    if platform.system() == "Windows":
+        # add quotes to allow for spaces in Windows directories
+        options.append(f'--config-file="{config_filepath}"')
+    else:
+        options.append(f'--config-file={config_filepath}')
 
     options_string = " ".join(options)
 
@@ -412,7 +417,6 @@ def convert_midi_to_wav_timidity(output_manager: data_manager.DataManager, timeo
 
                 # add file handler
                 log_filepath = os.path.join(os.getcwd(), f"log-timidity-{thread_index}.log")
-                # os.remove(log_filepath)
                 file_handler = logging.FileHandler(log_filepath, mode="w")
                 formatter = logging.Formatter("%(asctime)s - %(levelname)s: %(message)s")
                 file_handler.setFormatter(formatter)

--- a/qmuvi/musical_processing.py
+++ b/qmuvi/musical_processing.py
@@ -449,7 +449,7 @@ def convert_midi_to_wav_timidity(output_manager: data_manager.DataManager, timeo
                         subprocess.run([bundled_binary, "--version"],
                                     capture_output=True, check=True, timeout=0.5)
                         # If successful, use bundled version
-                        command = [bundled_binary] + options + ["-o", f'"{filename}.wav"', f'"{filename}.mid"']
+                        command = [bundled_binary] + options + ["-o", f'{filename}.wav', f'{filename}.mid']
                     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
                         pass # Bundled binary failed, will try system binary
                 if command is None:

--- a/qmuvi/musical_processing.py
+++ b/qmuvi/musical_processing.py
@@ -393,7 +393,7 @@ def convert_midi_to_wav_timidity(output_manager: data_manager.DataManager, timeo
 
     package_path = os.path.dirname(os.path.realpath(__file__))
     config_filepath = os.path.join(package_path, "package_data", "resources", "timidity", "timidity.cfg")
-    options.append(f'--config-file="{config_filepath}"')
+    options.append(f'--config-file={config_filepath}')
 
     options_string = " ".join(options)
 

--- a/qmuvi/quantum_simulation.py
+++ b/qmuvi/quantum_simulation.py
@@ -77,30 +77,4 @@ def sample_circuit_barriers(quantum_circuit: QuantumCircuit, noise_model: Option
     for i in range(barrier_count):
         density_matrices.append(result.data(0)[f"rho{i}"])
 
-    # dag = circuit_to_dag(quantum_circuit)
-    # qubit_count = len(dag.qubits)
-    # new_quantum_circuit = QuantumCircuit(qubit_count)
-    # quantum_circuits = []
-
-    # barrier_iter = 0
-    # for node in dag.topological_op_nodes():
-    #     if node.name == "barrier":
-    #         quantum_circuits.append(new_quantum_circuit.copy())
-    #         #new_quantum_circuit.save_density_matrix(label=f"rho{barrier_iter}")
-    #         barrier_iter += 1
-    #     if node.name != "measure":
-    #         new_quantum_circuit.append(node.op, node.qargs, node.cargs)
-    # barrier_count = barrier_iter
-
-    # density_matrices = []
-    # for qc in quantum_circuits:
-    #     transpiled_quantum_circuit = transpile(qc, simulator)
-
-    #     result : qiskit.Result = simulator.run(transpiled_quantum_circuit).result()
-    #     density_matrices.append(result.data(0)["density_matrix"])
-
-    # density_matrices = []
-    # for i in range(barrier_count):
-    #     density_matrices.append(result.data(0)[f"rho{i}"])
-
     return density_matrices


### PR DESCRIPTION
fixes #40

On macOS arm64 processors, Timidity needs to be manually installed with
```bash
brew install timidity
```

Added tests for all major platforms to github actions.